### PR TITLE
Refactor agreement terms flow to MVI

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/team_gori/gori/feature_login/presentation/AgreementTermsServiceScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/team_gori/gori/feature_login/presentation/AgreementTermsServiceScreen.kt
@@ -22,11 +22,11 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.team_gori.gori.designsystem.component.GoriCheckBox
@@ -49,6 +49,14 @@ fun AgreementTermsServiceScreen(
     val snackbarHostState = remember { SnackbarHostState() }
     val uiState by viewModel.uiState.collectAsState()
 
+    LaunchedEffect(Unit) {
+        viewModel.navEvent.collect { event ->
+            when (event) {
+                AgreementTermsServiceNavEvent.NavigateToSignUp -> onNavigateToSignUp()
+            }
+        }
+    }
+
     Box(modifier = Modifier.fillMaxSize()) {
         Scaffold(
             snackbarHost = { SnackbarHost(snackbarHostState) },
@@ -65,7 +73,7 @@ fun AgreementTermsServiceScreen(
                     },
                 )
             },
-        ) { innerPadding ->
+        ) {
             Column(
                 modifier = Modifier.padding(horizontal = 16.dp)
             ) {
@@ -79,7 +87,7 @@ fun AgreementTermsServiceScreen(
                 GoriCheckBox(
                     text = "네, 모두 동의합니다.",
                     checked = uiState.isAllAgreedChecked,
-                    onCheckChange = viewModel::onAllAgreedChange
+                    onCheckChange = { viewModel.onEvent(AgreementTermsServiceUiEvent.AllAgreementToggled(it)) }
                 )
                 HorizontalDivider(
                     thickness = 1.dp,
@@ -91,17 +99,17 @@ fun AgreementTermsServiceScreen(
                 GoriCheckBox(
                     text = "(필수) 서비스 이용약관 동의",
                     checked = uiState.termsAgreed,
-                    onCheckChange = viewModel::onTermsAgreedChange
+                    onCheckChange = { viewModel.onEvent(AgreementTermsServiceUiEvent.TermsAgreementToggled(it)) }
                 )
                 GoriCheckBox(
                     text = "(필수) 개인정보 수집 이용 동의",
                     checked = uiState.privacyAgreed,
-                    onCheckChange = viewModel::onPrivacyAgreedChange
+                    onCheckChange = { viewModel.onEvent(AgreementTermsServiceUiEvent.PrivacyAgreementToggled(it)) }
                 )
                 GoriCheckBox(
                     text = "(선택) 홍보 및 마케팅 이용 동의",
                     checked = uiState.marketingAgreed,
-                    onCheckChange = viewModel::onMarketingAgreedChange
+                    onCheckChange = { viewModel.onEvent(AgreementTermsServiceUiEvent.MarketingAgreementToggled(it)) }
                 )
                 Spacer(modifier = Modifier.weight(1f))
                 Button(
@@ -112,9 +120,7 @@ fun AgreementTermsServiceScreen(
                             color = Neutral30,
                             shape = RoundedCornerShape(size = 30.dp)
                         ),
-                    onClick = {
-                        onNavigateToSignUp()
-                    },
+                    onClick = { viewModel.onEvent(AgreementTermsServiceUiEvent.NextClicked) },
                     content = {
                         Text(
                             "다음",
@@ -122,7 +128,7 @@ fun AgreementTermsServiceScreen(
                             style = MaterialTheme.typography.headlineMedium
                         )
                     },
-                    enabled = viewModel.uiState.value.isNextButtonEnabled,
+                    enabled = uiState.isNextButtonEnabled,
                     colors = ButtonColors(
                         containerColor = MaterialTheme.semanticColors.labelNormal,
                         contentColor = MaterialTheme.semanticColors.onSecondary,

--- a/composeApp/src/commonMain/kotlin/com/team_gori/gori/feature_login/presentation/AgreementTermsServiceViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/team_gori/gori/feature_login/presentation/AgreementTermsServiceViewModel.kt
@@ -1,54 +1,79 @@
 package com.team_gori.gori.feature_login.presentation
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 
 class AgreementTermsServiceViewModel : ViewModel() {
-    private val _uiState = MutableStateFlow(AgreementUiState())
+    private val _uiState = MutableStateFlow(AgreementTermsServiceUiState())
     val uiState = _uiState.asStateFlow()
 
-    fun onAllAgreedChange(isChecked: Boolean) {
+    private val _navEvent = MutableSharedFlow<AgreementTermsServiceNavEvent>()
+    val navEvent = _navEvent.asSharedFlow()
+
+    fun onEvent(event: AgreementTermsServiceUiEvent) {
+        when (event) {
+            is AgreementTermsServiceUiEvent.AllAgreementToggled -> updateAllAgreements(event.isChecked)
+            is AgreementTermsServiceUiEvent.TermsAgreementToggled -> updateTermsAgreement(event.isChecked)
+            is AgreementTermsServiceUiEvent.PrivacyAgreementToggled -> updatePrivacyAgreement(event.isChecked)
+            is AgreementTermsServiceUiEvent.MarketingAgreementToggled -> updateMarketingAgreement(event.isChecked)
+            AgreementTermsServiceUiEvent.NextClicked -> navigateToSignUp()
+        }
+    }
+
+    private fun updateAllAgreements(isChecked: Boolean) {
         _uiState.update {
             it.copy(
                 allAgreed = isChecked,
                 termsAgreed = isChecked,
                 privacyAgreed = isChecked,
-                marketingAgreed = isChecked
+                marketingAgreed = isChecked,
             )
         }
     }
 
-    fun onTermsAgreedChange(isChecked: Boolean) {
+    private fun updateTermsAgreement(isChecked: Boolean) {
         _uiState.update { currentState ->
             currentState.copy(
                 termsAgreed = isChecked,
-                allAgreed = isChecked && currentState.privacyAgreed && currentState.marketingAgreed
+                allAgreed = isChecked && currentState.privacyAgreed && currentState.marketingAgreed,
             )
         }
     }
 
-    fun onPrivacyAgreedChange(isChecked: Boolean) {
+    private fun updatePrivacyAgreement(isChecked: Boolean) {
         _uiState.update { currentState ->
             currentState.copy(
                 privacyAgreed = isChecked,
-                allAgreed = currentState.termsAgreed && isChecked && currentState.marketingAgreed
+                allAgreed = currentState.termsAgreed && isChecked && currentState.marketingAgreed,
             )
         }
     }
 
-    fun onMarketingAgreedChange(isChecked: Boolean) {
+    private fun updateMarketingAgreement(isChecked: Boolean) {
         _uiState.update { currentState ->
             currentState.copy(
                 marketingAgreed = isChecked,
-                allAgreed = currentState.termsAgreed && currentState.privacyAgreed && isChecked
+                allAgreed = currentState.termsAgreed && currentState.privacyAgreed && isChecked,
             )
+        }
+    }
+
+    private fun navigateToSignUp() {
+        if (!_uiState.value.isNextButtonEnabled) return
+
+        viewModelScope.launch {
+            _navEvent.emit(AgreementTermsServiceNavEvent.NavigateToSignUp)
         }
     }
 }
 
-data class AgreementUiState(
+data class AgreementTermsServiceUiState(
     val allAgreed: Boolean = false,
     val termsAgreed: Boolean = false, // [필수] 이용약관
     val privacyAgreed: Boolean = false, // [필수] 개인정보
@@ -67,4 +92,16 @@ data class AgreementUiState(
      */
     val isNextButtonEnabled: Boolean
         get() = termsAgreed && privacyAgreed
+}
+
+sealed interface AgreementTermsServiceUiEvent {
+    data class AllAgreementToggled(val isChecked: Boolean) : AgreementTermsServiceUiEvent
+    data class TermsAgreementToggled(val isChecked: Boolean) : AgreementTermsServiceUiEvent
+    data class PrivacyAgreementToggled(val isChecked: Boolean) : AgreementTermsServiceUiEvent
+    data class MarketingAgreementToggled(val isChecked: Boolean) : AgreementTermsServiceUiEvent
+    data object NextClicked : AgreementTermsServiceUiEvent
+}
+
+sealed interface AgreementTermsServiceNavEvent {
+    data object NavigateToSignUp : AgreementTermsServiceNavEvent
 }


### PR DESCRIPTION
## Summary
- refactor the agreement terms view model to expose an explicit MVI contract with events and navigation side effects
- update the agreement terms screen to dispatch UI events to the view model and observe navigation events

## Testing
- ./gradlew :composeApp:compileDebugKotlinAndroid *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68daa64c3124832598613471dfabcf4a